### PR TITLE
fix: replace 3 bare except clauses with except Exception

### DIFF
--- a/wan/modules/animate/preprocess/pose2d_utils.py
+++ b/wan/modules/animate/preprocess/pose2d_utils.py
@@ -24,7 +24,7 @@ def read_img(image, convert='RGB', check_exist=False):
             img = Image.open(image)
             if convert:
                 img = img.convert(convert)
-        except:
+        except Exception:
             raise IOError('File error: ', image)
         return np.asarray(img)
     else:

--- a/wan/modules/animate/preprocess/process_pipepline.py
+++ b/wan/modules/animate/preprocess/process_pipepline.py
@@ -9,7 +9,7 @@ from loguru import logger
 from PIL import Image
 try:
     import moviepy.editor as mpy
-except:
+except Exception:
     import moviepy as mpy
 
 from decord import VideoReader

--- a/wan/modules/animate/preprocess/utils.py
+++ b/wan/modules/animate/preprocess/utils.py
@@ -137,7 +137,7 @@ def resize_by_area(image, target_area, keep_aspect_ratio=True, divisor=64, paddi
     h, w = image.shape[:2]
     try:
         new_w, new_h = calculate_new_size(w, h, target_area, divisor)
-    except:
+    except Exception:
         aspect_ratio = w / h
 
         if keep_aspect_ratio:


### PR DESCRIPTION
## What
Replace 3 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.