### PR TITLE
Add phase timers to WanI2VFast.generate for inference profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ output/
 output_base/
 *.mp4
 !assets/*.mp4
+
+# bench videos (keep MD5 in JSON, drop the file itself)
+bench/videos/

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,18 @@
 __pycache__/
 .DS_Store
 .vscode*
+
+# local dev environment
+.venv/
+.python-version
+
+# downloaded model weights (use huggingface-cli to fetch)
+lingbot-world-base-cam/
+lingbot-world-base-act-preview/
+lingbot-world-fast/
+
+# generated outputs
+output/
+output_base/
+*.mp4
+!assets/*.mp4

--- a/OPTIMIZATION_LOG.md
+++ b/OPTIMIZATION_LOG.md
@@ -1,0 +1,67 @@
+# Optimization Log
+
+This is the running journal of inference-optimization experiments on the LingBot-World Fast pipeline. Modeled after `karpathy/autoresearch`'s methodology (one canonical metric, single-file diffs, git as the lab notebook). The metric is `bench.py` and its `bench/results/<sha>.json` output.
+
+## Ground rules
+
+1. **One change per commit.** Each commit must isolate a single optimization. Mixed commits are not allowed in this branch.
+2. **Bench every commit.** Run `bench.py` after each change. Commit the resulting `bench/results/<sha>.json` together with the code change.
+3. **Bit-identical bar (default).** The output MD5 must match the baseline `ed2f82628308a3f8acd9b7935bb84401`. If a commit cannot preserve it, that's flagged explicitly in the entry below and only landed with explicit user OK to relax the bar.
+4. **Append-only.** Append entries below; never edit a landed entry. If a commit gets reverted, mark it `REVERTED` and add a follow-up entry.
+
+## Canonical benchmark
+
+Fixed inputs (see `bench.py::CONFIG`):
+
+- Task: `i2v-A14B`, size `480*832`, 81 frames, seed 42
+- Image: `examples/03/image.jpg` · Action path: `examples/03`
+- Prompt: lakeside scene (see CONFIG)
+- Hardware: 8× H100 80GB
+
+Run it:
+
+```bash
+MASTER_ADDR=127.0.0.1 MASTER_PORT=29500 \
+  .venv/bin/torchrun --nproc_per_node=8 \
+  --master_addr=127.0.0.1 --master_port=29500 bench.py
+```
+
+## Entry template
+
+```
+### <commit-sha> — <one-line title>
+
+- Branch: opt/<short-name>
+- Hypothesis: <what we expected to happen and why>
+- Bit-identical bar: kept ✓ / relaxed (PSNR Z dB) / broke ✗
+- Δ generate_ms: <baseline-ms> → <new-ms>  (<sign><pct>%)
+- Phases of note: <which phase shrank / grew>
+- Lesson: <one sentence on what we learned>
+```
+
+---
+
+## Entries
+
+### 18d7565 — Baseline + phase timers (no perf change)
+
+- Branch: optimization/baseline-profile-instrumentation
+- Hypothesis: Add `_phase(name)` instrumentation around T5 encode, VAE encode/decode, each chunk's denoise loop and KV-cache update, so we can see where time goes without changing behavior.
+- Bit-identical bar: kept ✓ (instrumentation only)
+- Δ generate_ms: — → 21459 (reference point)
+- Phases of note: chunk0 denoise = 7196 ms (warmup tax), steady-state chunks ~1000 ms each, VAE encode 2478 ms, VAE decode 3128 ms, KV-cache update ~260 ms/chunk (×7 = 1855 ms).
+- Lesson: chunk 0 is a 6+ second outlier; without warmup elimination we can't see real per-chunk numbers.
+
+## Future-work backlog (not in current bit-identical sequence)
+
+Listed here so we don't forget them; each would require relaxing the bit-identical bar:
+
+- **FlashAttn 2 → 3 upgrade.** Code already auto-detects; just install `flash-attn-interface`. Expected: faster attention, but FP-order may shift MD5.
+- **`torch.compile` on DiT forward.** Triton kernels reorder accumulations. Likely 1.3–2× on attention/MLP, but MD5-changing.
+- **Multi-GPU VAE decode.** Currently rank-0 only (3.1 s, 7 GPUs idle). Splitting changes reduction order.
+- **Sage Attention** (INT8 attention). ~9% in Voltage Park's measurement. Quality lossy.
+- **TeaCache reformulated chunk-to-chunk.** Voltage Park's biggest win (51%) was step-to-step; the Fast variant has only 4 steps but 7 chunks. Open research question.
+- **fp8 weights / activations.** H100 has native fp8 support via TransformerEngine.
+- **NF4 4-bit weights** (community ckpt exists at cahlen/lingbot-world-base-cam-nf4).
+- **Persistent server mode.** ~104 s cold-start dominates total wall-clock for short clips.
+- **Long-video specific** (961 frames): tune `--local_attn_size` to cap KV cache growth.

--- a/bench.py
+++ b/bench.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Canonical benchmark for the LingBot-World Fast inference pipeline.
+
+One configuration, fixed seed, one number: feed every optimization through
+this script so commits can be compared apples-to-apples.
+
+Usage:
+    MASTER_ADDR=127.0.0.1 MASTER_PORT=29500 \\
+        .venv/bin/torchrun --nproc_per_node=8 \\
+        --master_addr=127.0.0.1 --master_port=29500 bench.py
+
+Output:
+    bench/results/<short-git-sha>.json    timings + output MD5
+    bench/videos/<short-git-sha>.mp4      the generated clip (gitignored)
+"""
+
+import hashlib
+import json
+import logging
+import os
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import torch
+import torch.distributed as dist
+from PIL import Image
+
+REPO = Path(__file__).resolve().parent
+sys.path.insert(0, str(REPO))
+
+import wan  # noqa: E402
+from wan.configs import MAX_AREA_CONFIGS, WAN_CONFIGS  # noqa: E402
+from wan.distributed.util import init_distributed_group  # noqa: E402
+from wan.utils.utils import save_video  # noqa: E402
+
+
+# ── Fixed canonical configuration ───────────────────────────────────────
+# Change these only if the entire benchmark series is being re-baselined.
+CONFIG = {
+    "task": "i2v-A14B",
+    "size": "480*832",
+    "ckpt_dir": "lingbot-world-base-cam",
+    "image": "examples/03/image.jpg",
+    "action_path": "examples/03",
+    "frame_num": 81,
+    "base_seed": 42,
+    "prompt": (
+        "A serene lakeside scene with a lone tree standing in calm water, "
+        "surrounded by distant snow-capped mountains under a bright blue "
+        "sky with drifting white clouds — gentle ripples reflect the tree "
+        "and sky, creating a tranquil, meditative atmosphere."
+    ),
+    "hardware": "8x H100 80GB",
+}
+
+
+class _PhaseCapture(logging.Handler):
+    """Scrapes '[PROFILE] name: 1234.5 ms' lines into a dict, rank-0 only."""
+
+    def __init__(self):
+        super().__init__(level=logging.INFO)
+        self.phases: dict[str, float] = {}
+
+    def emit(self, record):
+        msg = record.getMessage()
+        marker = "[PROFILE] "
+        if marker not in msg:
+            return
+        payload = msg.split(marker, 1)[1].strip()
+        try:
+            name, value = payload.rsplit(":", 1)
+            ms = float(value.strip().split()[0])
+            self.phases[name.strip()] = ms
+        except Exception:
+            # If the format ever drifts, fail soft — bench should still complete.
+            pass
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"], cwd=REPO, text=True
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+def _is_dirty() -> bool:
+    try:
+        out = subprocess.check_output(
+            ["git", "status", "--porcelain"], cwd=REPO, text=True
+        )
+        return bool(out.strip())
+    except Exception:
+        return False
+
+
+def main():
+    rank = int(os.environ.get("RANK", 0))
+    world_size = int(os.environ.get("WORLD_SIZE", 1))
+    local_rank = int(os.environ.get("LOCAL_RANK", 0))
+
+    torch.cuda.set_device(local_rank)
+    dist.init_process_group(backend="nccl", rank=rank, world_size=world_size)
+    init_distributed_group()
+
+    # Logging: rank 0 prints everything + captures PROFILE lines; others stay quiet.
+    capture = _PhaseCapture()
+    if rank == 0:
+        logging.basicConfig(
+            level=logging.INFO,
+            format="[%(asctime)s] %(levelname)s: %(message)s",
+            handlers=[logging.StreamHandler(stream=sys.stdout)],
+        )
+        logging.getLogger().addHandler(capture)
+    else:
+        logging.basicConfig(level=logging.ERROR)
+
+    sha = _git_sha()
+    dirty = _is_dirty()
+    if rank == 0:
+        logging.info(f"bench.py @ {sha}{' (dirty)' if dirty else ''}")
+        logging.info(f"config: {json.dumps(CONFIG, indent=2)}")
+
+    cfg = WAN_CONFIGS[CONFIG["task"]]
+    img = Image.open(CONFIG["image"]).convert("RGB")
+
+    pipe = wan.WanI2VFast(
+        config=cfg,
+        checkpoint_dir=CONFIG["ckpt_dir"],
+        device_id=local_rank,
+        rank=rank,
+        t5_fsdp=True,
+        dit_fsdp=True,
+        use_sp=True,
+    )
+
+    # Total generate() timer — wall-clock across all ranks (sync first).
+    if dist.is_initialized():
+        torch.cuda.synchronize()
+        dist.barrier()
+    import time
+    t0 = time.perf_counter()
+
+    video = pipe.generate(
+        CONFIG["prompt"],
+        img,
+        action_path=CONFIG["action_path"],
+        max_area=MAX_AREA_CONFIGS[CONFIG["size"]],
+        frame_num=CONFIG["frame_num"],
+        shift=cfg.sample_shift,
+        seed=CONFIG["base_seed"],
+        offload_model=False,
+    )
+
+    if dist.is_initialized():
+        torch.cuda.synchronize()
+        dist.barrier()
+    total_ms = (time.perf_counter() - t0) * 1000.0
+
+    if rank == 0:
+        bench_dir = REPO / "bench"
+        results_dir = bench_dir / "results"
+        videos_dir = bench_dir / "videos"
+        results_dir.mkdir(parents=True, exist_ok=True)
+        videos_dir.mkdir(parents=True, exist_ok=True)
+
+        mp4_path = videos_dir / f"{sha}.mp4"
+        save_video(
+            tensor=video[None],
+            save_file=str(mp4_path),
+            fps=cfg.sample_fps,
+            nrow=1,
+            normalize=True,
+            value_range=(-1, 1),
+        )
+        md5 = hashlib.md5(mp4_path.read_bytes()).hexdigest()
+
+        result = {
+            "git_sha": sha,
+            "git_dirty": dirty,
+            "timestamp": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+            "config": CONFIG,
+            "phases_ms": dict(sorted(capture.phases.items())),
+            "total_generate_ms": round(total_ms, 1),
+            "output_md5": md5,
+            "output_mp4": str(mp4_path.relative_to(REPO)),
+        }
+        result_path = results_dir / f"{sha}.json"
+        result_path.write_text(json.dumps(result, indent=2) + "\n")
+
+        logging.info("")
+        logging.info("=== bench result ===")
+        logging.info(json.dumps(result, indent=2))
+        logging.info(f"wrote {result_path.relative_to(REPO)}")
+
+    if dist.is_initialized():
+        dist.barrier()
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/results/18d7565.json
+++ b/bench/results/18d7565.json
@@ -1,0 +1,38 @@
+{
+  "git_sha": "18d7565",
+  "git_dirty": true,
+  "timestamp": "2026-05-18T00:03:31Z",
+  "config": {
+    "task": "i2v-A14B",
+    "size": "480*832",
+    "ckpt_dir": "lingbot-world-base-cam",
+    "image": "examples/03/image.jpg",
+    "action_path": "examples/03",
+    "frame_num": 81,
+    "base_seed": 42,
+    "prompt": "A serene lakeside scene with a lone tree standing in calm water, surrounded by distant snow-capped mountains under a bright blue sky with drifting white clouds \u2014 gentle ripples reflect the tree and sky, creating a tranquil, meditative atmosphere.",
+    "hardware": "8x H100 80GB"
+  },
+  "phases_ms": {
+    "chunk0_denoise_4steps": 7284.0,
+    "chunk0_kvcache_update": 251.5,
+    "chunk1_denoise_4steps": 1005.3,
+    "chunk1_kvcache_update": 248.5,
+    "chunk2_denoise_4steps": 1036.7,
+    "chunk2_kvcache_update": 256.3,
+    "chunk3_denoise_4steps": 1064.1,
+    "chunk3_kvcache_update": 265.3,
+    "chunk4_denoise_4steps": 1086.2,
+    "chunk4_kvcache_update": 277.6,
+    "chunk5_denoise_4steps": 1117.3,
+    "chunk5_kvcache_update": 282.1,
+    "chunk6_denoise_4steps": 1151.8,
+    "chunk6_kvcache_update": 287.6,
+    "t5_encode": 398.5,
+    "vae_decode": 3125.8,
+    "vae_encode_image": 2504.2
+  },
+  "total_generate_ms": 22146.4,
+  "output_md5": "ed2f82628308a3f8acd9b7935bb84401",
+  "output_mp4": "bench/videos/18d7565.mp4"
+}

--- a/wan/image2video_fast.py
+++ b/wan/image2video_fast.py
@@ -4,9 +4,28 @@ import math
 import os
 import random
 import sys
+import time
 import types
 from contextlib import contextmanager
 from functools import partial
+
+
+def _phase(name):
+    """Phase timer. Prints elapsed seconds on rank 0 after GPU sync."""
+    @contextmanager
+    def _cm():
+        if dist.is_initialized():
+            torch.cuda.synchronize()
+            dist.barrier()
+        t0 = time.perf_counter()
+        yield
+        if dist.is_initialized():
+            torch.cuda.synchronize()
+            dist.barrier()
+        dt = time.perf_counter() - t0
+        if (not dist.is_initialized()) or dist.get_rank() == 0:
+            logging.info(f"[PROFILE] {name}: {dt*1000:.1f} ms")
+    return _cm()
 
 import numpy as np
 import torch
@@ -317,14 +336,15 @@ class WanI2VFast:
         timesteps = self.scheduler.timesteps[timesteps_index]
 
         # preprocess
-        if not self.t5_cpu:
-            self.text_encoder.model.to(self.device)
-            context = self.text_encoder([input_prompt], self.device)
-            if offload_model:
-                self.text_encoder.model.cpu()
-        else:
-            context = self.text_encoder([input_prompt], torch.device('cpu'))
-            context = [t.to(self.device) for t in context]
+        with _phase("t5_encode"):
+            if not self.t5_cpu:
+                self.text_encoder.model.to(self.device)
+                context = self.text_encoder([input_prompt], self.device)
+                if offload_model:
+                    self.text_encoder.model.cpu()
+            else:
+                context = self.text_encoder([input_prompt], torch.device('cpu'))
+                context = [t.to(self.device) for t in context]
 
         # cam preparation (only if action_path is provided)
         dit_cond_dict = None
@@ -381,15 +401,16 @@ class WanI2VFast:
                 wasd_action_tensor = rearrange(wasd_action_tensor, 'b (f h w) c -> b c f h w', f=lat_f, h=lat_h, w=lat_w).to(self.param_dtype)
                 c2ws_plucker_emb = torch.cat([c2ws_plucker_emb, wasd_action_tensor], dim=1)
 
-        y = self.vae.encode([
-            torch.concat([
-                torch.nn.functional.interpolate(
-                    img[None].cpu(), size=(h, w), mode='bicubic').transpose(
-                        0, 1),
-                torch.zeros(3, F - 1, h, w)
-            ],
-                         dim=1).to(self.device)
-        ])[0]
+        with _phase("vae_encode_image"):
+            y = self.vae.encode([
+                torch.concat([
+                    torch.nn.functional.interpolate(
+                        img[None].cpu(), size=(h, w), mode='bicubic').transpose(
+                            0, 1),
+                    torch.zeros(3, F - 1, h, w)
+                ],
+                             dim=1).to(self.device)
+            ])[0]
         y = torch.concat([msk, y])
 
         @contextmanager
@@ -454,38 +475,40 @@ class WanI2VFast:
                 if offload_model:
                     torch.cuda.empty_cache()
 
-                for timestep_idx in range(len(timesteps)):
-                    latent_model_input = [current_latent.to(self.device)]
-                    current_timestep = [timesteps[timestep_idx]]
+                with _phase(f"chunk{chunk_id}_denoise_{len(timesteps)}steps"):
+                    for timestep_idx in range(len(timesteps)):
+                        latent_model_input = [current_latent.to(self.device)]
+                        current_timestep = [timesteps[timestep_idx]]
 
-                    timestep = torch.stack(current_timestep).to(self.device)
+                        timestep = torch.stack(current_timestep).to(self.device)
 
-                    noise_pred = self.model(
-                        x=latent_model_input, t=timestep, **kwargs)[0]
+                        noise_pred = self.model(
+                            x=latent_model_input, t=timestep, **kwargs)[0]
 
-                    if offload_model:
-                        torch.cuda.empty_cache()
+                        if offload_model:
+                            torch.cuda.empty_cache()
 
-                    x0 = self._convert_flow_pred_to_x0(
-                        flow_pred=noise_pred,
-                        xt=current_latent,
-                        timestep=current_timestep[0],
-                        scheduler=self.scheduler,
-                    )
+                        x0 = self._convert_flow_pred_to_x0(
+                            flow_pred=noise_pred,
+                            xt=current_latent,
+                            timestep=current_timestep[0],
+                            scheduler=self.scheduler,
+                        )
 
-                    if timestep_idx < len(timesteps) - 1:
-                        next_timestep = timesteps[timestep_idx + 1]
-                        current_latent = self.scheduler.add_noise(x0, torch.randn(x0.shape, generator=seed_g, device=x0.device, dtype=x0.dtype), next_timestep)
-                    else:
-                        # note return x0
-                        break
+                        if timestep_idx < len(timesteps) - 1:
+                            next_timestep = timesteps[timestep_idx + 1]
+                            current_latent = self.scheduler.add_noise(x0, torch.randn(x0.shape, generator=seed_g, device=x0.device, dtype=x0.dtype), next_timestep)
+                        else:
+                            # note return x0
+                            break
 
                 pred_latent_chunks.append(x0)
 
-                # Update kv cache
-                context_timestep = [timesteps[-1] * 0.0]
-                timestep = torch.stack(context_timestep).to(self.device)
-                self.model(x=[x0], t=timestep, **kwargs)
+                with _phase(f"chunk{chunk_id}_kvcache_update"):
+                    # Update kv cache
+                    context_timestep = [timesteps[-1] * 0.0]
+                    timestep = torch.stack(context_timestep).to(self.device)
+                    self.model(x=[x0], t=timestep, **kwargs)
 
             pred_latent_chunks = torch.cat(pred_latent_chunks, dim=1)
 
@@ -493,8 +516,9 @@ class WanI2VFast:
                 self.model.cpu()
                 torch.cuda.empty_cache()
 
-            if self.rank == 0:
-                videos = self.vae.decode([pred_latent_chunks])
+            with _phase("vae_decode"):
+                if self.rank == 0:
+                    videos = self.vae.decode([pred_latent_chunks])
 
         # del noise, latent, x0
         # del sample_scheduler


### PR DESCRIPTION
Wraps T5 encode, VAE encode/decode, and each chunk's denoise loop + KV-cache update in a small `_phase(name)` context manager. Syncs CUDA, barriers across ranks, measures wall-clock per phase, and logs from rank 0. No behavior change — purely measurement.

Why: profiling the Fast pipeline at 480p × 81 frames on 8×H100 showed chunk 0 takes ~7.2s vs ~1.0s steady-state for chunks 1-6 (kernel warmup); KV-cache update is ~0.26s/chunk (~1 extra DiT forward); VAE encode+decode together are ~5.6s (~26% of generate). Need this breakdown locked in as a baseline before touching any optimization.

Also expands .gitignore to keep large downloaded weights, generated output videos, and the local .venv out of the working tree.