### PR TITLE
perf(fsdp): SHARD_GRAD_OP for inference (-13.7%, -1855ms, bit-identical)

### DIFF
--- a/wan/distributed/fsdp.py
+++ b/wan/distributed/fsdp.py
@@ -19,10 +19,19 @@ def shard_model(
     sync_module_states=True,
     use_lora=False
 ):
+    # Inference-only optimization: keep parameters gathered after the
+    # first forward. FSDP1's equivalent of FSDP2's reshard_after_forward=False
+    # is ShardingStrategy.SHARD_GRAD_OP — only grads/optimizer state are
+    # sharded; params are unsharded after the first all-gather and stay
+    # resident across forwards. Memory cost: ~28GB unsharded params per
+    # rank (vs ~3.5GB sharded across 8 ranks), but at 80GB H100 we have
+    # headroom. Profiling identified AllGather as 91% of NCCL time
+    # (975 ms / 2-chunk window) — skipping the per-forward re-gather
+    # across the 35 forwards in a generate() should reclaim most of it.
     model = FSDP(
         module=model,
         process_group=process_group,
-        sharding_strategy=sharding_strategy,
+        sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
         auto_wrap_policy=partial(
             lambda_auto_wrap_policy, lambda_fn=lambda m: m in model.blocks),
         mixed_precision=MixedPrecision(


### PR DESCRIPTION
## Summary

Switches DiT FSDP from `FULL_SHARD` to `SHARD_GRAD_OP`. Parameters stay resident across all 35 DiT forwards in a `generate()` instead of being re-gathered per-forward. **Bit-identical output** (MD5 `ed2f82628308a3f8acd9b7935bb84401`), **−13.7% generate()**.

`SHARD_GRAD_OP` is FSDP1's equivalent of FSDP2's `reshard_after_forward=False` (the FSDP2 kwarg isn't accepted by the current PyTorch's FSDP1 constructor).

## Measurement (8×H100, 480×832, 81 frames, seed 42)

Stacked on top of #51 (B3) for the canonical chain:

| Stage | `generate()` | vs unopt | vs prior |
|---|---:|---:|---:|
| Unoptimized | 22146 ms | — | — |
| + `prewarm()` (PR #48) | 15564 ms | −30% | — |
| + T5 cache (PR #50) | 15134 ms | −32% | −2.8% |
| + B3 (PR #51) | 13523 ms | −39% | −10.6% |
| **+ this PR** | **11668 ms** | **−47%** | **−13.7%** |

## Why

Profiling the post-B3 baseline showed AllGather was 91% of NCCL time — 975 ms over a 2-chunk window. With `FULL_SHARD`, FSDP shards params after each forward and re-gathers on the next call. Across the 35 forwards in one `generate()`, that re-gather fires repeatedly. `SHARD_GRAD_OP` keeps params unsharded after the first all-gather — the per-forward re-gather disappears.

## Memory

Unsharded 14B-param DiT at bf16 ≈ 28 GB per rank vs ~3.5 GB sharded across 8 ranks. On 80 GB H100s with VAE + T5 + KV cache + activations resident, there is headroom; no OOM observed across multiple bench runs.

## Tradeoffs / scope

- Purely an inference-mode optimization. If anyone runs this code in a training context, the `FULL_SHARD` default would need to come back via a flag — happy to add one if requested.
- Bit-identical (Tier A): MD5 match verified end-to-end at the locked baseline.
- One file changed (`wan/distributed/fsdp.py`); ~10 LOC including comment block.

## Stack

Stacked on PR #51 (B3). Reported diff will shrink to one line + comment once that lands.