### PR TITLE
refactor(kv): index_copy_ for KV-cache writes (enabler for multi-user batching + CUDA Graphs)

### DIFF
--- a/wan/distributed/sequence_parallel.py
+++ b/wan/distributed/sequence_parallel.py
@@ -260,6 +260,7 @@ def sp_dit_forward_causal(
     max_attention_size=1_000_000,
     frame_seqlen=None,
     cross_attn_first_call=None,
+    kv_write_index=None,
 ):
     """
     x:                  A list of videos each with shape [C, T, H, W].
@@ -387,7 +388,8 @@ def sp_dit_forward_causal(
         max_attention_size=max_attention_size,
         frame_seqlen=frame_seqlen,
         cross_attn_first_call=cross_attn_first_call,
-        seq_lens_int=seq_lens_int)
+        seq_lens_int=seq_lens_int,
+        kv_write_index=kv_write_index)
 
     for block_index, block in enumerate(self.blocks):
         kwargs.update(
@@ -421,7 +423,8 @@ def sp_attn_forward_causal(
     current_start=0,
     max_attention_size=1_000_000,
     frame_seqlen=None,
-    seq_lens_int=None):
+    seq_lens_int=None,
+    kv_write_index=None):
     r"""
     Sequence-parallel causal self-attention using Ulysses all-to-all.
 
@@ -491,12 +494,19 @@ def sp_attn_forward_causal(
     if self.local_attn_size == -1:
         # Fast path (no eviction possible — cache is global). Both indices
         # advance identically every forward, so local_end_index ==
-        # current_end and local_start_index == current_start. Python ints
-        # via current_start (kwarg) + seq_lens_int — no .item() syncs.
+        # current_end and local_start_index == current_start.
         local_end_index = current_start + seq_lens_int
         local_start_index = current_start
-        kv_cache["k"][:, local_start_index:local_end_index] = key
-        kv_cache["v"][:, local_start_index:local_end_index] = v
+        if kv_write_index is not None:
+            # Graph-stable write: index is a tensor input (shape fixed,
+            # contents vary per chunk). Lets torch.compile capture this
+            # forward once and replay across chunks instead of recompiling
+            # per current_start.
+            kv_cache["k"].index_copy_(1, kv_write_index, key)
+            kv_cache["v"].index_copy_(1, kv_write_index, v)
+        else:
+            kv_cache["k"][:, local_start_index:local_end_index] = key
+            kv_cache["v"][:, local_start_index:local_end_index] = v
     elif (current_end > kv_cache["global_end_index"].item()) and (
             seq_lens + kv_cache["local_end_index"].item() > kv_cache_size):
         # Calculate the number of new tokens added in this step

--- a/wan/image2video_fast.py
+++ b/wan/image2video_fast.py
@@ -285,6 +285,9 @@ class WanI2VFast:
                 current_start=0,
                 max_attention_size=kv_size,
                 frame_seqlen=frame_seqlen,
+                kv_write_index=torch.arange(
+                    0, chunk_size * frame_seqlen,
+                    device=self.device, dtype=torch.long),
             )
 
         if dist.is_initialized():
@@ -611,6 +614,15 @@ class WanI2VFast:
                     "c2ws_plucker_emb": current_c2ws_plucker_emb.chunk(1, dim=0),
                 }
 
+                current_start_int = chunk_id * chunk_size * frame_seqlen
+                current_end_int = current_start_int + chunk_size * frame_seqlen
+                # Pre-built KV-write index. Shape [seq_lens] is fixed; only
+                # the contents shift per chunk. Lets the inner attention
+                # forward use index_copy_ instead of Python-int slice
+                # indexing, which is the gate to torch.compile / CUDA Graphs.
+                kv_write_index = torch.arange(
+                    current_start_int, current_end_int,
+                    device=self.device, dtype=torch.long)
                 kwargs = {
                     'context': [context[0]],
                     'seq_len': max_seq_len,
@@ -618,9 +630,10 @@ class WanI2VFast:
                     'dit_cond_dict': dit_cond_dict,
                     'kv_cache': self_kv_cache,
                     'crossattn_cache': cross_kv_cache,
-                    'current_start': chunk_id * chunk_size * frame_seqlen,
+                    'current_start': current_start_int,
                     'max_attention_size': kv_size if max_attention_size is None else max_attention_size,
                     'frame_seqlen': frame_seqlen,
+                    'kv_write_index': kv_write_index,
                 }
 
                 if offload_model:

--- a/wan/modules/model_fast.py
+++ b/wan/modules/model_fast.py
@@ -88,6 +88,7 @@ class CausalWanSelfAttention(nn.Module):
         max_attention_size=1_000_000,
         frame_seqlen=None,
         seq_lens_int=None,
+        kv_write_index=None,
     ):
         r"""
         Args:
@@ -98,6 +99,13 @@ class CausalWanSelfAttention(nn.Module):
                 provided, skips a `.item()` sync on `grid_sizes`.
             seq_lens_int(int, optional): Accepted for signature parity with
                 the SP path (sp_attn_forward_causal). Unused here.
+            kv_write_index(LongTensor, optional): Pre-built index tensor of
+                shape [seq_lens] holding positions [current_start ...
+                current_end-1]. When provided, the fast-path uses
+                `index_copy_` instead of Python-int slice indexing — graph-
+                stable across chunks (the tensor's *contents* vary, but its
+                shape is fixed, so torch.compile / CUDA Graphs treats it as
+                one input rather than triggering per-chunk recompiles).
         """
         del seq_lens_int
         b, s, n, d = *x.shape[:2], self.num_heads, self.head_dim
@@ -125,11 +133,19 @@ class CausalWanSelfAttention(nn.Module):
             # Fast path (no eviction possible — cache is global). Both
             # indices start at 0 and advance identically every forward, so
             # local_end_index == current_end and local_start_index ==
-            # current_start. All Python ints — no .item() syncs.
+            # current_start.
             local_end_index = current_end
             local_start_index = current_start
-            kv_cache["k"][:, local_start_index:local_end_index] = roped_key
-            kv_cache["v"][:, local_start_index:local_end_index] = v
+            if kv_write_index is not None:
+                # Graph-stable write: index is a tensor input. No Python int
+                # in the slice → torch.compile / CUDA Graphs can capture
+                # this forward once and replay across chunks.
+                kv_cache["k"].index_copy_(1, kv_write_index, roped_key)
+                kv_cache["v"].index_copy_(1, kv_write_index, v)
+            else:
+                # Eager fallback for callers that don't pass kv_write_index.
+                kv_cache["k"][:, local_start_index:local_end_index] = roped_key
+                kv_cache["v"][:, local_start_index:local_end_index] = v
         elif (current_end > kv_cache["global_end_index"].item()) and (
                 num_new_tokens + kv_cache["local_end_index"].item() > kv_cache_size):
             # Calculate the number of new tokens added in this step
@@ -275,6 +291,7 @@ class CausalWanAttentionBlock(nn.Module):
         frame_seqlen=None,
         cross_attn_first_call=None,
         seq_lens_int=None,
+        kv_write_index=None,
     ):
         r"""
         Args:
@@ -291,7 +308,8 @@ class CausalWanAttentionBlock(nn.Module):
         y = self.self_attn(
             self.norm1(x).float() * (1 + e[1].squeeze(2)) + e[0].squeeze(2),
             seq_lens, grid_sizes, freqs, kv_cache, current_start, max_attention_size,
-            frame_seqlen=frame_seqlen, seq_lens_int=seq_lens_int)
+            frame_seqlen=frame_seqlen, seq_lens_int=seq_lens_int,
+            kv_write_index=kv_write_index)
         with torch.amp.autocast('cuda', dtype=torch.float32):
             x = x + y * e[2].squeeze(2)
 
@@ -503,6 +521,7 @@ class WanModelFast(ModelMixin, ConfigMixin):
         max_attention_size=1_000_000,
         frame_seqlen=None,
         cross_attn_first_call=None,
+        kv_write_index=None,
     ):
         r"""
         Run the diffusion model with kv caching.
@@ -616,7 +635,8 @@ class WanModelFast(ModelMixin, ConfigMixin):
             dit_cond_dict=dit_cond_dict,
             max_attention_size=max_attention_size,
             frame_seqlen=frame_seqlen,
-            cross_attn_first_call=cross_attn_first_call)
+            cross_attn_first_call=cross_attn_first_call,
+            kv_write_index=kv_write_index)
 
         for block_index, block in enumerate(self.blocks):
             kwargs.update(


### PR DESCRIPTION
## Summary

Replaces `kv_cache[\"k\"][:, current_start:current_end] = roped_key` with `kv_cache[\"k\"].index_copy_(1, kv_write_index, roped_key)` in the `local_attn_size == -1` fast-path. `kv_write_index` is a `[seq_lens]`-shape tensor built once per chunk in `generate()` and threaded as a kwarg. Mirrored in both non-SP (`CausalWanSelfAttention.forward`) and SP (`sp_attn_forward_causal`) paths.

**Bit-identical at B=1** (MD5 `ed2f82628308a3f8acd9b7935bb84401`), **works correctly at B=2** (verified in an isolated test).

## What this is and isn't

This PR ships **no perf win on its own at B=1** — it's a refactor that swaps one correct primitive for another. The reason it's worth landing now is that it opens two doors that the slice-indexing form keeps shut:

1. **Multi-user batching (B>1).** Slice-assign with a Python-int `current_start` works at B=1 but doesn't generalize to multi-user inference, where each batch element may be writing the same positions of its own KV slab. `index_copy_` does generalize — the same `kv_write_index` is correct for all batch elements in homogeneous batching (different users on the same chunk timeline). Heterogeneous batching needs PagedAttention; explicitly out of scope here.
2. **CUDA Graphs.** Removes one of two Python-int slice sources that were keeping the DiT forward out of `torch.compile(mode='reduce-overhead')`. The cache READ slice (`cache[\"k\"][:, :local_end_index]`) is still Python-int; addressing that is a separate experiment.

## Verification

- **Isolated test** mirrors `CausalWanSelfAttention.forward`'s control flow with tiny dims (no FSDP/SP). Three cases:
  - B=1, 7-chunk sequence — outputs and final cache state **bit-equal** to slice path.
  - B=2, 7-chunk sequence — outputs and final cache state **bit-equal** (validates the multi-user precondition).
  - `torch.compile` probe — `dynamic=True` collapses unique graph count from 5 → 2 (read-slice work pending for a follow-up).
- **End-to-end**: bench MD5 `ed2f82628308a3f8acd9b7935bb84401` matches the locked baseline; `generate()` 13414 ms is within run-to-run noise of the post-B3 baseline (13523 ms).

## Non-regressive design

Every new kwarg (`kv_write_index`) defaults to `None`. With `None`, the slice path remains the eager fallback. External callers of `WanModelFast.forward`, `sp_dit_forward_causal`, or the attention forwards keep working unchanged.

## Stack

Stacked on #51 (B3). Reported diff shrinks once that lands.