### PR TITLE
feat(batch): enable B>1 DiT forward in SP path (1.42× at B=2, B=1 bit-identical)

### DIFF
--- a/wan/distributed/fsdp.py
+++ b/wan/distributed/fsdp.py
@@ -19,10 +19,19 @@ def shard_model(
     sync_module_states=True,
     use_lora=False
 ):
+    # Inference-only optimization: keep parameters gathered after the
+    # first forward. FSDP1's equivalent of FSDP2's reshard_after_forward=False
+    # is ShardingStrategy.SHARD_GRAD_OP — only grads/optimizer state are
+    # sharded; params are unsharded after the first all-gather and stay
+    # resident across forwards. Memory cost: ~28GB unsharded params per
+    # rank (vs ~3.5GB sharded across 8 ranks), but at 80GB H100 we have
+    # headroom. Profiling identified AllGather as 91% of NCCL time
+    # (975 ms / 2-chunk window) — skipping the per-forward re-gather
+    # across the 35 forwards in a generate() should reclaim most of it.
     model = FSDP(
         module=model,
         process_group=process_group,
-        sharding_strategy=sharding_strategy,
+        sharding_strategy=ShardingStrategy.SHARD_GRAD_OP,
         auto_wrap_policy=partial(
             lambda_auto_wrap_policy, lambda_fn=lambda m: m in model.blocks),
         mixed_precision=MixedPrecision(

--- a/wan/distributed/sequence_parallel.py
+++ b/wan/distributed/sequence_parallel.py
@@ -286,7 +286,9 @@ def sp_dit_forward_causal(
     updates the KV cache, runs attention, then all-to-all back.
     """
 
-    assert len(x) == 1
+    # B>1 batched inference (E3 probe): assertion lifted. Downstream uses
+    # of seq_lens / grid_sizes assume homogeneous shape across batch.
+    # assert len(x) == 1
 
     if self.model_type == 'i2v':
         assert y is not None
@@ -320,7 +322,12 @@ def sp_dit_forward_causal(
 
     # time embeddings
     if t.dim() == 1:
-        t = t.expand(t.size(0), padded_seq_lens)
+        # E3: was `t.expand(t.size(0), padded_seq_lens)`, which only works
+        # when t is shape [1] (singleton expandable to anything). For B>1
+        # t is shape [B] and expand fails — add a unit dim first so the
+        # broadcast is [B, 1] → [B, padded_seq_lens]. Identical to the
+        # original at B=1.
+        t = t.unsqueeze(1).expand(t.size(0), padded_seq_lens)
     with torch.amp.autocast('cuda', dtype=torch.float32):
         bt = t.size(0)
         t = t.flatten()
@@ -350,8 +357,11 @@ def sp_dit_forward_causal(
                 c3=self.patch_size[2],
             ) for i in c2ws_plucker_emb
         ]
-        c2ws_plucker_emb = torch.cat(c2ws_plucker_emb,
-                                     dim=1)  # [1, (L1+...+Ln), C]
+        # E3: cat along batch dim. For B=1 (one element in the list) this
+        # is a no-op vs the original dim=1; for B>1 (multi-user) each user
+        # keeps its own camera conditioning instead of being merged into
+        # one batch=1 sequence.
+        c2ws_plucker_emb = torch.cat(c2ws_plucker_emb, dim=0)  # [B, L, C]
         c2ws_plucker_emb = self.patch_embedding_wancamctrl(c2ws_plucker_emb)
         c2ws_hidden_states = self.c2ws_hidden_states_layer2(
             torch_F.silu(self.c2ws_hidden_states_layer1(c2ws_plucker_emb)))

--- a/wan/distributed/sequence_parallel.py
+++ b/wan/distributed/sequence_parallel.py
@@ -260,6 +260,7 @@ def sp_dit_forward_causal(
     max_attention_size=1_000_000,
     frame_seqlen=None,
     cross_attn_first_call=None,
+    kv_write_index=None,
 ):
     """
     x:                  A list of videos each with shape [C, T, H, W].
@@ -387,7 +388,8 @@ def sp_dit_forward_causal(
         max_attention_size=max_attention_size,
         frame_seqlen=frame_seqlen,
         cross_attn_first_call=cross_attn_first_call,
-        seq_lens_int=seq_lens_int)
+        seq_lens_int=seq_lens_int,
+        kv_write_index=kv_write_index)
 
     for block_index, block in enumerate(self.blocks):
         kwargs.update(
@@ -421,7 +423,8 @@ def sp_attn_forward_causal(
     current_start=0,
     max_attention_size=1_000_000,
     frame_seqlen=None,
-    seq_lens_int=None):
+    seq_lens_int=None,
+    kv_write_index=None):
     r"""
     Sequence-parallel causal self-attention using Ulysses all-to-all.
 
@@ -491,12 +494,19 @@ def sp_attn_forward_causal(
     if self.local_attn_size == -1:
         # Fast path (no eviction possible — cache is global). Both indices
         # advance identically every forward, so local_end_index ==
-        # current_end and local_start_index == current_start. Python ints
-        # via current_start (kwarg) + seq_lens_int — no .item() syncs.
+        # current_end and local_start_index == current_start.
         local_end_index = current_start + seq_lens_int
         local_start_index = current_start
-        kv_cache["k"][:, local_start_index:local_end_index] = key
-        kv_cache["v"][:, local_start_index:local_end_index] = v
+        if kv_write_index is not None:
+            # Graph-stable write: index is a tensor input (shape fixed,
+            # contents vary per chunk). Lets torch.compile capture this
+            # forward once and replay across chunks instead of recompiling
+            # per current_start.
+            kv_cache["k"].index_copy_(1, kv_write_index, key)
+            kv_cache["v"].index_copy_(1, kv_write_index, v)
+        else:
+            kv_cache["k"][:, local_start_index:local_end_index] = key
+            kv_cache["v"][:, local_start_index:local_end_index] = v
     elif (current_end > kv_cache["global_end_index"].item()) and (
             seq_lens + kv_cache["local_end_index"].item() > kv_cache_size):
         # Calculate the number of new tokens added in this step

--- a/wan/image2video_fast.py
+++ b/wan/image2video_fast.py
@@ -285,6 +285,9 @@ class WanI2VFast:
                 current_start=0,
                 max_attention_size=kv_size,
                 frame_seqlen=frame_seqlen,
+                kv_write_index=torch.arange(
+                    0, chunk_size * frame_seqlen,
+                    device=self.device, dtype=torch.long),
             )
 
         if dist.is_initialized():
@@ -611,6 +614,15 @@ class WanI2VFast:
                     "c2ws_plucker_emb": current_c2ws_plucker_emb.chunk(1, dim=0),
                 }
 
+                current_start_int = chunk_id * chunk_size * frame_seqlen
+                current_end_int = current_start_int + chunk_size * frame_seqlen
+                # Pre-built KV-write index. Shape [seq_lens] is fixed; only
+                # the contents shift per chunk. Lets the inner attention
+                # forward use index_copy_ instead of Python-int slice
+                # indexing, which is the gate to torch.compile / CUDA Graphs.
+                kv_write_index = torch.arange(
+                    current_start_int, current_end_int,
+                    device=self.device, dtype=torch.long)
                 kwargs = {
                     'context': [context[0]],
                     'seq_len': max_seq_len,
@@ -618,9 +630,10 @@ class WanI2VFast:
                     'dit_cond_dict': dit_cond_dict,
                     'kv_cache': self_kv_cache,
                     'crossattn_cache': cross_kv_cache,
-                    'current_start': chunk_id * chunk_size * frame_seqlen,
+                    'current_start': current_start_int,
                     'max_attention_size': kv_size if max_attention_size is None else max_attention_size,
                     'frame_seqlen': frame_seqlen,
+                    'kv_write_index': kv_write_index,
                 }
 
                 if offload_model:

--- a/wan/modules/model_fast.py
+++ b/wan/modules/model_fast.py
@@ -88,6 +88,7 @@ class CausalWanSelfAttention(nn.Module):
         max_attention_size=1_000_000,
         frame_seqlen=None,
         seq_lens_int=None,
+        kv_write_index=None,
     ):
         r"""
         Args:
@@ -98,6 +99,13 @@ class CausalWanSelfAttention(nn.Module):
                 provided, skips a `.item()` sync on `grid_sizes`.
             seq_lens_int(int, optional): Accepted for signature parity with
                 the SP path (sp_attn_forward_causal). Unused here.
+            kv_write_index(LongTensor, optional): Pre-built index tensor of
+                shape [seq_lens] holding positions [current_start ...
+                current_end-1]. When provided, the fast-path uses
+                `index_copy_` instead of Python-int slice indexing — graph-
+                stable across chunks (the tensor's *contents* vary, but its
+                shape is fixed, so torch.compile / CUDA Graphs treats it as
+                one input rather than triggering per-chunk recompiles).
         """
         del seq_lens_int
         b, s, n, d = *x.shape[:2], self.num_heads, self.head_dim
@@ -125,11 +133,19 @@ class CausalWanSelfAttention(nn.Module):
             # Fast path (no eviction possible — cache is global). Both
             # indices start at 0 and advance identically every forward, so
             # local_end_index == current_end and local_start_index ==
-            # current_start. All Python ints — no .item() syncs.
+            # current_start.
             local_end_index = current_end
             local_start_index = current_start
-            kv_cache["k"][:, local_start_index:local_end_index] = roped_key
-            kv_cache["v"][:, local_start_index:local_end_index] = v
+            if kv_write_index is not None:
+                # Graph-stable write: index is a tensor input. No Python int
+                # in the slice → torch.compile / CUDA Graphs can capture
+                # this forward once and replay across chunks.
+                kv_cache["k"].index_copy_(1, kv_write_index, roped_key)
+                kv_cache["v"].index_copy_(1, kv_write_index, v)
+            else:
+                # Eager fallback for callers that don't pass kv_write_index.
+                kv_cache["k"][:, local_start_index:local_end_index] = roped_key
+                kv_cache["v"][:, local_start_index:local_end_index] = v
         elif (current_end > kv_cache["global_end_index"].item()) and (
                 num_new_tokens + kv_cache["local_end_index"].item() > kv_cache_size):
             # Calculate the number of new tokens added in this step
@@ -275,6 +291,7 @@ class CausalWanAttentionBlock(nn.Module):
         frame_seqlen=None,
         cross_attn_first_call=None,
         seq_lens_int=None,
+        kv_write_index=None,
     ):
         r"""
         Args:
@@ -291,7 +308,8 @@ class CausalWanAttentionBlock(nn.Module):
         y = self.self_attn(
             self.norm1(x).float() * (1 + e[1].squeeze(2)) + e[0].squeeze(2),
             seq_lens, grid_sizes, freqs, kv_cache, current_start, max_attention_size,
-            frame_seqlen=frame_seqlen, seq_lens_int=seq_lens_int)
+            frame_seqlen=frame_seqlen, seq_lens_int=seq_lens_int,
+            kv_write_index=kv_write_index)
         with torch.amp.autocast('cuda', dtype=torch.float32):
             x = x + y * e[2].squeeze(2)
 
@@ -503,6 +521,7 @@ class WanModelFast(ModelMixin, ConfigMixin):
         max_attention_size=1_000_000,
         frame_seqlen=None,
         cross_attn_first_call=None,
+        kv_write_index=None,
     ):
         r"""
         Run the diffusion model with kv caching.
@@ -616,7 +635,8 @@ class WanModelFast(ModelMixin, ConfigMixin):
             dit_cond_dict=dit_cond_dict,
             max_attention_size=max_attention_size,
             frame_seqlen=frame_seqlen,
-            cross_attn_first_call=cross_attn_first_call)
+            cross_attn_first_call=cross_attn_first_call,
+            kv_write_index=kv_write_index)
 
         for block_index, block in enumerate(self.blocks):
             kwargs.update(


### PR DESCRIPTION
## Summary

Three minimal changes to `sp_dit_forward_causal` that unlock batched multi-user inference. Each is a no-op at B=1; together they let B>1 run correctly through the same path.

**B=1 bit-identical** (MD5 `ed2f82628308a3f8acd9b7935bb84401`). **B=2 throughput: 1.42×** (single-chunk forward, two distinct users batched).

## What changed

| Site | Fix | Why no-op at B=1 |
|---|---|---|
| `assert len(x) == 1` | removed | Assertion was always true at B=1; surrounding code already handles a list. |
| `torch.cat(c2ws, dim=1)` → `dim=0` | each user keeps its own camera conditioning | One-element list — both dims give the same tensor. |
| `t.expand(B, S)` → `t.unsqueeze(1).expand(B, S)` | works for any B | At B=1 the broadcast result is identical. |

## Verification

```
B=1 bench:    MD5 ed2f82628308a3f8acd9b7935bb84401 (locked baseline)
              generate() 11690 ms (noise vs prior)

B=2 probe:    user A match (atol=3e-2): PASS
              user B match (atol=3e-2): PASS
              throughput 1.42× (272 ms for 2 users vs 388 ms sequential)
```

Tolerance is set at bf16 attention precision (flash-attn reduces matmuls in different orders for B=1 vs B=2 → tiny numerical drift, max abs diff 1.8e-2 / mean 2.8e-3 across ~1M elements).

## Scope

Lifts the inner DiT forward only. The higher-level `generate()` loop still constructs B=1 inputs, so production paths are unchanged. Multi-user serving infrastructure (per-user session, continuous-batching scheduler, PagedAttention for heterogeneous timelines) is separate follow-on work.

## Stack

Stacks on #51, #52, #53. Reported diff shrinks once those land.