### PR TITLE
fix: export CUDA devices in run_fast.sh

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf

--- a/run_fast.sh
+++ b/run_fast.sh
@@ -1,32 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
 
-set -x 
+if [ "$#" -ne 2 ]; then
+    echo "Usage: bash run_fast.sh <weights_dir> <frame_num>" >&2
+    exit 2
+fi
 
 WEIGHT_DIR=$1
 FRAME=$2
+CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0,1,2,3,4,5,6,7}
+NPROC_PER_NODE=${NPROC_PER_NODE:-8}
+export CUDA_VISIBLE_DEVICES
 
 # case1
-CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7; torchrun --nproc_per_node=8 generate_fast.py \
+torchrun --nproc_per_node=${NPROC_PER_NODE} generate_fast.py \
                            --task i2v-A14B \
                            --size 480*832 \
-                           --ckpt_dir ${WEIGHT_DIR} \
+                           --ckpt_dir "${WEIGHT_DIR}" \
                            --image examples/03/image.jpg \
                            --action_path examples/03 \
                            --dit_fsdp \
                            --t5_fsdp \
-                           --ulysses_size 8 \
-                           --frame_num ${FRAME} \
+                           --ulysses_size "${NPROC_PER_NODE}" \
+                           --frame_num "${FRAME}" \
                            --prompt "A serene lakeside scene with a lone tree standing in calm water, surrounded by distant snow-capped mountains under a bright blue sky with drifting white clouds — gentle ripples reflect the tree and sky, creating a tranquil, meditative atmosphere."
 
 
 # case2
-CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7; torchrun --nproc_per_node=8 generate_fast.py \
+torchrun --nproc_per_node=${NPROC_PER_NODE} generate_fast.py \
                            --task i2v-A14B \
                            --size 480*832 \
-                           --ckpt_dir ${WEIGHT_DIR} \
+                           --ckpt_dir "${WEIGHT_DIR}" \
                            --image examples/04/image.jpg \
                            --action_path examples/04 \
                            --dit_fsdp \
                            --t5_fsdp \
-                           --ulysses_size 8 \
-                           --frame_num ${FRAME} \
+                           --ulysses_size "${NPROC_PER_NODE}" \
+                           --frame_num "${FRAME}" \
                            --prompt "A sweeping cinematic journey along the Great Wall of China, winding through golden autumn hills under a brilliant blue sky — stone pathways stretch into the distance, watchtowers stand sentinel, and vibrant foliage blankets the mountainsides as the camera glides smoothly forward, capturing the grandeur and timeless majesty of this ancient wonder."


### PR DESCRIPTION
## Description

Fixes `run_fast.sh` so CUDA device selection is actually exported to the `torchrun` subprocess.

The default behavior remains the same: the script still uses devices `0,1,2,3,4,5,6,7` and `8` processes unless the caller overrides them. The script now also accepts `CUDA_VISIBLE_DEVICES` and `NPROC_PER_NODE` from the environment, adds an argument usage check, quotes user-provided paths, and keeps shell scripts checked out with LF line endings.

## Related Issue

This was found while checking the provided fast inference runner.

## Motivation and Context

The previous script used this form:

```bash
CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7; torchrun ...
```

With the semicolon, the variable assignment is not exported to the `torchrun` child process. Using a shared exported default makes the runner behave as intended and makes overrides explicit.

## How Has This Been / Can This Be Tested?

Environment: WSL2 Ubuntu2204.

```bash
bash -n run_fast.sh
```

Stubbed `torchrun` to avoid launching model inference and verified both cases receive the overridden environment and process count:

```bash
CUDA_VISIBLE_DEVICES=2,3 NPROC_PER_NODE=2 bash run_fast.sh /tmp/weights 9
```

Observed both generated `torchrun` invocations include:

```text
CUDA_VISIBLE_DEVICES=2,3
--nproc_per_node=2
--ulysses_size 2
```

Also ran:

```bash
git diff --check origin/main...HEAD
```

## Checklist

- [x] Preserves the default 8-GPU runner behavior.
- [x] Allows explicit `CUDA_VISIBLE_DEVICES` / `NPROC_PER_NODE` overrides.
- [x] Avoids launching full inference in validation.
